### PR TITLE
Feature/#140202775/display real time search results

### DIFF
--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -23,25 +23,49 @@ function getProductFindTerm(searchTerm, searchTags, userId) {
 
 export const getResults = {};
 
-getResults.products = function (searchTerm, facets, maxResults, userId) {
-  const searchTags = facets || [];
-  const findTerm = getProductFindTerm(searchTerm, searchTags, userId);
-  const productResults = ProductSearch.find(findTerm,
-    {
-      fields: {
-        score: {$meta: "textScore"},
-        title: 1,
-        hashtags: 1,
-        description: 1,
-        handle: 1,
-        price: 1
-      },
-      sort: {score: {$meta: "textScore"}},
-      limit: maxResults
-    }
-  );
+getResults.products = function (searchTerm, facets, maxResults) {
+  let productResults;
+  const shopId = Reaction.getShopId();
+  const findTerm = {
+    $and: [
+      {shopId: shopId},
+      {$or: [
+        { description: {
+          $regex: searchTerm,
+          $options: "i"
+        }},
+        { searchTags: {
+          $regex: searchTerm,
+          $options: "i"
+        }},
+        { title: {
+          $regex: searchTerm,
+          $options: "i"
+        }},
+        { hashtags: {
+          $regex: searchTerm,
+          $options: "i"
+        }},
+        { handle: {
+          $regex: searchTerm,
+          $options: "i"
+        }},
+        { price: {
+          $regex: searchTerm,
+          $options: "i"
+        }},
+        { score: {
+          $regex: searchTerm,
+          $options: "i"
+        }}
+      ]}
+    ]};
+  productResults = ProductSearch.find(findTerm, {
+    limit: maxResults
+  });
   return productResults;
 };
+
 
 getResults.orders = function (searchTerm, facets, maxResults, userId) {
   let orderResults;

--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -12,34 +12,13 @@ function getProductFindTerm(searchTerm, searchTags, userId) {
     $and: [
       {shopId: shopId},
       {$or: [
-        { description: {
-          $regex: searchTerm,
-          $options: "i"
-        }},
-        { searchTags: {
-          $regex: searchTerm,
-          $options: "i"
-        }},
-        { title: {
-          $regex: searchTerm,
-          $options: "i"
-        }},
-        { hashtags: {
-          $regex: searchTerm,
-          $options: "i"
-        }},
-        { handle: {
-          $regex: searchTerm,
-          $options: "i"
-        }},
-        { price: {
-          $regex: searchTerm,
-          $options: "i"
-        }},
-        { score: {
-          $regex: searchTerm,
-          $options: "i"
-        }}
+        { description: {$regex: searchTerm, $options: "i"}},
+        { searchTags: {$regex: searchTerm, $options: "i"}},
+        { title: {$regex: searchTerm, $options: "i"}},
+        { hashtags: { $regex: searchTerm, $options: "i"}},
+        { handle: {$regex: searchTerm, $options: "i"}},
+        { price: {$regex: searchTerm, $options: "i"}},
+        { score: {$regex: searchTerm, $options: "i"}}
       ]}
     ]
   };


### PR DESCRIPTION
**What does this PR do?**
This PR ensures that a real-time search result is displayed when user is searching for keywords on reaction commerce

**Description of Task to be completed?**
Modify the current search to be similar to a google search, display relevant results on the page as a user is typing rather than wait until they submit the search

**How should this be manually tested?**
On the reaction commerce application, click on the search icon and then type to see real-time matching results.

**What are the relevant pivotal tracker stories?**
#140202775. Display real-time results as shopper is typing. 

**Screenshots (if appropriate)**
<img width="1674" alt="screen shot 2017-03-08 at 1 56 21 pm" src="https://cloud.githubusercontent.com/assets/24938070/23704842/1893ecc8-0407-11e7-92c7-0890ee470638.png">


